### PR TITLE
Update job_card.py

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -673,15 +673,22 @@ class JobCard(Document):
 		):
 			total_completed_qty_label = bold(_("Total Completed Qty"))
 			qty_to_manufacture = bold(_("Qty to Manufacture"))
+			wo_qty = flt(frappe.get_cached_value("Work Order", self.work_order, "qty"))
 
-			frappe.throw(
-				_("The {0} ({1}) must be equal to {2} ({3})").format(
-					total_completed_qty_label,
-					bold(flt(total_completed_qty, precision)),
-					qty_to_manufacture,
-					bold(self.for_quantity),
+			over_production_percentage = flt(frappe.db.get_single_value("Manufacturing Settings", "overproduction_percentage_for_work_order"))
+
+			wo_qty = wo_qty + (wo_qty * over_production_percentage / 100)
+			
+			if flt(qty_to_manufacture,precision) > flt(wo_qty,precision):
+
+				frappe.throw(
+					_("The {0} ({1}) must be equal to {2} ({3})").format(
+						total_completed_qty_label,
+						bold(flt(total_completed_qty, precision)),
+						qty_to_manufacture,
+						bold(self.for_quantity),
+					)
 				)
-			)
 
 	def set_expected_and_actual_time(self):
 		for child_table, start_field, end_field, time_required in [


### PR DESCRIPTION
The overproduction percentage is entered in the manufacturing settings. However, the overproduction percentage is not considered on job cards, preventing the entry of overproduction quantity in the job card.